### PR TITLE
Remove unused deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro": "astro",
-    "deploy": "pnpm build && gh-pages -d dist"
+    "astro": "astro"
   },
   "dependencies": {
     "@astrojs/react": "^4.3.0",
@@ -20,7 +19,6 @@
     "tailwindcss": "^4.1.11"
   },
   "devDependencies": {
-    "gh-pages": "^6.3.0"
   },
   "packageManager": "pnpm@9.1.4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,10 +32,7 @@ importers:
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
-    devDependencies:
-      gh-pages:
-        specifier: ^6.3.0
-        version: 6.3.0
+    devDependencies: {}
 
 packages:
 
@@ -1079,10 +1076,6 @@ packages:
     resolution: {integrity: sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==}
     engines: {node: '>=18'}
 
-  gh-pages@6.3.0:
-    resolution: {integrity: sha512-Ot5lU6jK0Eb+sszG8pciXdjMXdBJ5wODvgjR+imihTqsUWF2K6dJ9HST55lgqcs8wWcw6o6wAsUzfcYRhJPXbA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -3092,15 +3085,6 @@ snapshots:
 
   get-east-asian-width@1.3.0: {}
 
-  gh-pages@6.3.0:
-    dependencies:
-      async: 3.2.6
-      commander: 13.1.0
-      email-addresses: 5.0.0
-      filenamify: 4.3.0
-      find-cache-dir: 3.3.2
-      fs-extra: 11.3.0
-      globby: 11.1.0
 
   github-slugger@2.0.0: {}
 


### PR DESCRIPTION
## Summary
- drop `deploy` script
- drop `gh-pages` package from deps
- update lockfile

## Testing
- `pnpm build` *(fails: cannot fetch pnpm)*

------
https://chatgpt.com/codex/tasks/task_e_685f019053e88327a076c14379cf06dd