### PR TITLE
Add bilingual routes

### DIFF
--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -8,7 +8,7 @@ const { t, lang = 'en' } = Astro.props;
     style='font-family: Inter, "Noto Sans", sans-serif;'
 >
     <div class="layout-container flex h-full grow flex-col">
-        <Header t={t.nav} lang={lang} />
+        <Header t={t} lang={lang} />
         <div class="px-40 flex flex-1 justify-center py-5">
             <div
                 class="layout-content-container flex flex-col max-w-[960px] flex-1"

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,5 +1,6 @@
 ---
 import Header from "./Header.astro";
+const { t, lang = 'en' } = Astro.props;
 ---
 
 <div
@@ -7,7 +8,7 @@ import Header from "./Header.astro";
     style='font-family: Inter, "Noto Sans", sans-serif;'
 >
     <div class="layout-container flex h-full grow flex-col">
-        <Header />
+        <Header t={t.nav} lang={lang} />
         <div class="px-40 flex flex-1 justify-center py-5">
             <div
                 class="layout-content-container flex flex-col max-w-[960px] flex-1"
@@ -26,18 +27,17 @@ import Header from "./Header.astro";
                                 <p
                                     class="text-[#121416] text-[22px] font-bold leading-tight tracking-[-0.015em] text-center"
                                 >
-                                    Miguel Angel Pineda Vega
+                                    {t.profileName}
                                 </p>
                                 <p
                                     class="text-[#6a7681] text-base font-normal leading-normal text-center"
                                 >
-                                    DevOps Developer
+                                    {t.role}
                                 </p>
                                 <p
                                     class="text-[#6a7681] text-base font-normal leading-normal text-center"
                                 >
-                                    Experienced DevOps professional with a
-                                    passion for automation and efficiency.
+                                    {t.profileDesc}
                                 </p>
                             </div>
                         </div>
@@ -46,24 +46,17 @@ import Header from "./Header.astro";
                 <h2
                     class="text-[#121416] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
                 >
-                    About Me
+                    {t.aboutTitle}
                 </h2>
                 <p
                     class="text-[#121416] text-base font-normal leading-normal pb-3 pt-1 px-4"
                 >
-                    I am a seasoned DevOps engineer with over 5 years of
-                    experience in automating and streamlining software
-                    development and deployment processes. My expertise lies in
-                    building scalable and resilient infrastructure, implementing
-                    CI/CD pipelines, and fostering a collaborative DevOps
-                    culture. I am dedicated to continuous learning and staying
-                    abreast of the latest technologies to deliver innovative
-                    solutions.
+                    {t.aboutDesc1}
                 </p>
                 <h2
                     class="text-[#121416] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
                 >
-                    Technical Skills
+                    {t.skillsTitle}
                 </h2>
                 <div class="flex gap-3 p-3 flex-wrap pr-4">
                     <div
@@ -72,7 +65,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Cloud Computing
+                            {t.skills[0]}
                         </p>
                     </div>
                     <div
@@ -81,7 +74,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Infrastructure as Code
+                            {t.skills[1]}
                         </p>
                     </div>
                     <div
@@ -90,7 +83,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            CI/CD
+                            {t.skills[2]}
                         </p>
                     </div>
                     <div
@@ -99,7 +92,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Containerization
+                            {t.skills[3]}
                         </p>
                     </div>
                     <div
@@ -108,7 +101,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Orchestration
+                            {t.skills[4]}
                         </p>
                     </div>
                     <div
@@ -117,7 +110,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Monitoring
+                            {t.skills[5]}
                         </p>
                     </div>
                     <div
@@ -126,7 +119,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Logging
+                            {t.skills[6]}
                         </p>
                     </div>
                     <div
@@ -135,7 +128,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Scripting
+                            {t.skills[7]}
                         </p>
                     </div>
                     <div
@@ -144,7 +137,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Configuration Management
+                            {t.skills[8]}
                         </p>
                     </div>
                     <div
@@ -153,14 +146,14 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Version Control
+                            {t.skills[9]}
                         </p>
                     </div>
                 </div>
                 <h2
                     class="text-[#121416] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
                 >
-                    Tools
+                    {t.toolsTitle}
                 </h2>
                 <div class="flex gap-3 p-3 flex-wrap pr-4">
                     <div
@@ -169,7 +162,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            AWS
+                            {t.tools[0]}
                         </p>
                     </div>
                     <div
@@ -178,7 +171,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Azure
+                            {t.tools[1]}
                         </p>
                     </div>
                     <div
@@ -187,7 +180,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            GCP
+                            {t.tools[2]}
                         </p>
                     </div>
                     <div
@@ -196,7 +189,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Docker
+                            {t.tools[3]}
                         </p>
                     </div>
                     <div
@@ -205,7 +198,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Kubernetes
+                            {t.tools[4]}
                         </p>
                     </div>
                     <div
@@ -214,7 +207,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Jenkins
+                            {t.tools[5]}
                         </p>
                     </div>
                     <div
@@ -223,7 +216,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            GitLab CI
+                            {t.tools[6]}
                         </p>
                     </div>
                     <div
@@ -232,7 +225,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Terraform
+                            {t.tools[7]}
                         </p>
                     </div>
                     <div
@@ -241,7 +234,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Ansible
+                            {t.tools[8]}
                         </p>
                     </div>
                     <div
@@ -250,7 +243,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Prometheus
+                            {t.tools[9]}
                         </p>
                     </div>
                     <div
@@ -259,7 +252,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Grafana
+                            {t.tools[10]}
                         </p>
                     </div>
                     <div
@@ -268,14 +261,14 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Git
+                            {t.tools[11]}
                         </p>
                     </div>
                 </div>
                 <h2
                     class="text-[#121416] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
                 >
-                    Methodologies
+                    {t.methodologiesTitle}
                 </h2>
                 <div class="flex gap-3 p-3 flex-wrap pr-4">
                     <div
@@ -284,7 +277,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Agile
+                            {t.methodologies[0]}
                         </p>
                     </div>
                     <div
@@ -293,7 +286,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Scrum
+                            {t.methodologies[1]}
                         </p>
                     </div>
                     <div
@@ -302,7 +295,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            Kanban
+                            {t.methodologies[2]}
                         </p>
                     </div>
                     <div
@@ -311,7 +304,7 @@ import Header from "./Header.astro";
                         <p
                             class="text-[#121416] text-sm font-medium leading-normal"
                         >
-                            DevOps
+                            {t.methodologies[3]}
                         </p>
                     </div>
                 </div>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -8,7 +8,7 @@ const { t, lang = 'en' } = Astro.props;
     style='font-family: Inter, "Noto Sans", sans-serif;'
 >
     <div class="layout-container flex h-full grow flex-col">
-        <Header t={t.nav} lang={lang} />
+        <Header t={t} lang={lang} />
         <div class="px-40 flex flex-1 justify-center py-5">
             <div
                 class="layout-content-container flex flex-col max-w-[960px] flex-1"

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,5 +1,6 @@
 ---
 import Header from "./Header.astro"
+const { t, lang = 'en' } = Astro.props;
 ---
 
 <div
@@ -7,7 +8,7 @@ import Header from "./Header.astro"
     style='font-family: Inter, "Noto Sans", sans-serif;'
 >
     <div class="layout-container flex h-full grow flex-col">
-        <Header />
+        <Header t={t.nav} lang={lang} />
         <div class="px-40 flex flex-1 justify-center py-5">
             <div
                 class="layout-content-container flex flex-col max-w-[960px] flex-1"
@@ -17,14 +18,12 @@ import Header from "./Header.astro"
                         <p
                             class="text-[#111518] tracking-light text-[32px] font-bold leading-tight"
                         >
-                            Get in Touch
+                            {t.title}
                         </p>
                         <p
                             class="text-[#60768a] text-sm font-normal leading-normal"
                         >
-                            I'm always open to discussing new projects, creative
-                            ideas, or opportunities to be part of your visions.
-                            Feel free to reach out!
+                            {t.desc}
                         </p>
                     </div>
                 </div>
@@ -35,10 +34,10 @@ import Header from "./Header.astro"
                         <p
                             class="text-[#111518] text-base font-medium leading-normal pb-2"
                         >
-                            Your Name
+                            {t.nameLabel}
                         </p>
                         <input
-                            placeholder="Enter your name"
+                            placeholder={t.namePlaceholder}
                             class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#111518] focus:outline-0 focus:ring-0 border border-[#dbe1e6] bg-white focus:border-[#dbe1e6] h-14 placeholder:text-[#60768a] p-[15px] text-base font-normal leading-normal"
                             value=""
                         />
@@ -51,10 +50,10 @@ import Header from "./Header.astro"
                         <p
                             class="text-[#111518] text-base font-medium leading-normal pb-2"
                         >
-                            Email Address
+                            {t.emailLabel}
                         </p>
                         <input
-                            placeholder="Enter your email"
+                            placeholder={t.emailPlaceholder}
                             class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#111518] focus:outline-0 focus:ring-0 border border-[#dbe1e6] bg-white focus:border-[#dbe1e6] h-14 placeholder:text-[#60768a] p-[15px] text-base font-normal leading-normal"
                             value=""
                         />
@@ -67,10 +66,10 @@ import Header from "./Header.astro"
                         <p
                             class="text-[#111518] text-base font-medium leading-normal pb-2"
                         >
-                            Your Message
+                            {t.messageLabel}
                         </p>
                         <textarea
-                            placeholder="How can I help you?"
+                            placeholder={t.messagePlaceholder}
                             class="form-input flex w-full min-w-0 flex-1 resize-none overflow-hidden rounded-xl text-[#111518] focus:outline-0 focus:ring-0 border border-[#dbe1e6] bg-white focus:border-[#dbe1e6] min-h-36 placeholder:text-[#60768a] p-[15px] text-base font-normal leading-normal"
                         ></textarea>
                     </label>
@@ -79,23 +78,23 @@ import Header from "./Header.astro"
                     <button
                         class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-full h-10 px-4 bg-[#0b80ee] text-white text-sm font-bold leading-normal tracking-[0.015em]"
                     >
-                        <span class="truncate">Send Message</span>
+                        <span class="truncate">{t.sendButton}</span>
                     </button>
                 </div>
                 <h3
                     class="text-[#111518] text-lg font-bold leading-tight tracking-[-0.015em] px-4 pb-2 pt-4"
                 >
-                    Contact Information
+                    {t.infoTitle}
                 </h3>
                 <p
                     class="text-[#111518] text-base font-normal leading-normal pb-3 pt-1 px-4"
                 >
-                    Email: contact@devopspro.com
+                    {t.infoEmail}
                 </p>
                 <p
                     class="text-[#111518] text-base font-normal leading-normal pb-3 pt-1 px-4"
                 >
-                    Phone: (555) 123-4567
+                    {t.infoPhone}
                 </p>
                 <div class="@container">
                     <div class="gap-2 px-4 flex flex-wrap justify-start">
@@ -125,7 +124,7 @@ import Header from "./Header.astro"
                             <p
                                 class="text-[#111518] text-sm font-medium leading-normal"
                             >
-                                Twitter
+                                {t.socials.twitter}
                             </p>
                         </div>
                         <div
@@ -154,7 +153,7 @@ import Header from "./Header.astro"
                             <p
                                 class="text-[#111518] text-sm font-medium leading-normal"
                             >
-                                LinkedIn
+                                {t.socials.linkedin}
                             </p>
                         </div>
                         <div
@@ -183,7 +182,7 @@ import Header from "./Header.astro"
                             <p
                                 class="text-[#111518] text-sm font-medium leading-normal"
                             >
-                                GitHub
+                                {t.socials.github}
                             </p>
                         </div>
                     </div>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,3 +1,7 @@
+---
+const { t, lang = 'en' } = Astro.props;
+---
+
 <header
     class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f1f2f4] px-10 py-3"
 >
@@ -21,15 +25,19 @@
         <div class="flex items-center gap-9">
             <a
                 class="text-[#121416] text-sm font-medium leading-normal"
-                href="/about">About</a
+                href={lang === 'en' ? '/about' : '/es/about'}>{t.nav.about}</a
             >
             <a
                 class="text-[#121416] text-sm font-medium leading-normal"
-                href="#">Projects</a
+                href="#">{t.nav.projects}</a
             >
             <a
                 class="text-[#121416] text-sm font-medium leading-normal"
-                href="/contact">Contact</a
+                href={lang === 'en' ? '/contact' : '/es/contact'}>{t.nav.contact}</a
+            >
+            <a
+                class="text-[#121416] text-sm font-medium leading-normal"
+                href={lang === 'en' ? '/es/' : '/'}>{lang === 'en' ? 'ES' : 'EN'}</a
             >
         </div>
         <div

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,16 @@
 ---
-const { t, lang = 'en' } = Astro.props;
+const { t, lang = "en" } = Astro.props;
 ---
+
+<script>
+    window.changeIdiom = () => {
+        const current = window.location.pathname;
+        const newPath = current.startsWith("/es")
+            ? current.replace(/^\/es/, "") || "/"
+            : `/es${current}`;
+        window.location.href = newPath;
+    };
+</script>
 
 <header
     class="flex items-center justify-between whitespace-nowrap border-b border-solid border-b-[#f1f2f4] px-10 py-3"
@@ -17,7 +27,10 @@ const { t, lang = 'en' } = Astro.props;
                     fill="currentColor"></path>
             </svg>
         </div>
-        <a href="/" class="text-[#121416] text-lg font-bold leading-tight tracking-[-0.015em]">
+        <a
+            href="/"
+            class="text-[#121416] text-lg font-bold leading-tight tracking-[-0.015em]"
+        >
             Miguel Pineda
         </a>
     </div>
@@ -25,7 +38,7 @@ const { t, lang = 'en' } = Astro.props;
         <div class="flex items-center gap-9">
             <a
                 class="text-[#121416] text-sm font-medium leading-normal"
-                href={lang === 'en' ? '/about' : '/es/about'}>{t.nav.about}</a
+                href={lang === "en" ? "/about" : "/es/about"}>{t.nav.about}</a
             >
             <a
                 class="text-[#121416] text-sm font-medium leading-normal"
@@ -33,11 +46,12 @@ const { t, lang = 'en' } = Astro.props;
             >
             <a
                 class="text-[#121416] text-sm font-medium leading-normal"
-                href={lang === 'en' ? '/contact' : '/es/contact'}>{t.nav.contact}</a
+                href={lang === "en" ? "/contact" : "/es/contact"}
+                >{t.nav.contact}</a
             >
             <a
-                class="text-[#121416] text-sm font-medium leading-normal"
-                href={lang === 'en' ? '/es/' : '/'}>{lang === 'en' ? 'ES' : 'EN'}</a
+                class="text-[#121416] text-sm font-medium leading-normal cursor-pointer"
+                onclick="changeIdiom()">{lang === "en" ? "ES" : "EN"}</a
             >
         </div>
         <div

--- a/src/components/Welcome.astro
+++ b/src/components/Welcome.astro
@@ -8,7 +8,7 @@ const { t, lang = 'en' } = Astro.props;
 	style='font-family: Inter, "Noto Sans", sans-serif;'
 >
 	<div class="layout-container flex h-full grow flex-col">
-                <Header t={t.nav} lang={lang} />
+                <Header t={t} lang={lang} />
 		<div class="px-40 flex flex-1 justify-center py-5">
 			<div
 				class="layout-content-container flex flex-col max-w-[960px] flex-1"

--- a/src/components/Welcome.astro
+++ b/src/components/Welcome.astro
@@ -1,5 +1,6 @@
 ---
 import Header from "./Header.astro";
+const { t, lang = 'en' } = Astro.props;
 ---
 
 <div
@@ -7,7 +8,7 @@ import Header from "./Header.astro";
 	style='font-family: Inter, "Noto Sans", sans-serif;'
 >
 	<div class="layout-container flex h-full grow flex-col">
-		<Header />
+                <Header t={t.nav} lang={lang} />
 		<div class="px-40 flex flex-1 justify-center py-5">
 			<div
 				class="layout-content-container flex flex-col max-w-[960px] flex-1"
@@ -22,32 +23,27 @@ import Header from "./Header.astro";
 								<h1
 									class="text-white text-4xl font-black leading-tight tracking-[-0.033em] @[480px]:text-5xl @[480px]:font-black @[480px]:leading-tight @[480px]:tracking-[-0.033em]"
 								>
-									Streamline Your Operations with Expert
-									DevOps Solutions
+                                                                {t.heroTitle}
 								</h1>
 								<h2
 									class="text-white text-sm font-normal leading-normal @[480px]:text-base @[480px]:font-normal @[480px]:leading-normal"
 								>
-									I specialize in optimizing software
-									development and deployment processes,
-									ensuring seamless integration and efficient
-									workflows. Let's transform your business
-									with cutting-edge DevOps practices.
+                                                                {t.heroSubtitle}
 								</h2>
 							</div>
 							<button
 								class="flex min-w-[84px] max-w-[480px] cursor-pointer items-center justify-center overflow-hidden rounded-lg h-10 px-4 @[480px]:h-12 @[480px]:px-5 bg-[#0c7ff2] text-white text-sm font-bold leading-normal tracking-[0.015em] @[480px]:text-base @[480px]:font-bold @[480px]:leading-normal @[480px]:tracking-[0.015em]"
 							>
-								<span class="truncate">Explore Services</span>
+                                                                <span class="truncate">{t.buttonExplore}</span>
 							</button>
 						</div>
 					</div>
 				</div>
-				<h2
-					class="text-[#111418] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
-				>
-					My Services
-				</h2>
+                                <h2
+                                        class="text-[#111418] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
+                                >
+                                        {t.servicesTitle}
+                                </h2>
 				<div
 					class="grid grid-cols-[repeat(auto-fit,minmax(158px,1fr))] gap-3 p-4"
 				>
@@ -76,13 +72,12 @@ import Header from "./Header.astro";
 							<h2
 								class="text-[#111418] text-base font-bold leading-tight"
 							>
-								Infrastructure Automation
+                                                                {t.services[0].title}
 							</h2>
 							<p
 								class="text-[#60758a] text-sm font-normal leading-normal"
 							>
-								Automate your infrastructure management for
-								scalability and reliability.
+                                                                {t.services[0].description}
 							</p>
 						</div>
 					</div>
@@ -111,14 +106,12 @@ import Header from "./Header.astro";
 							<h2
 								class="text-[#111418] text-base font-bold leading-tight"
 							>
-								Continuous Integration/Continuous Deployment
-								(CI/CD)
+                                                                {t.services[1].title}
 							</h2>
 							<p
 								class="text-[#60758a] text-sm font-normal leading-normal"
 							>
-								Implement CI/CD pipelines for faster and more
-								reliable software releases.
+                                                                {t.services[1].description}
 							</p>
 						</div>
 					</div>
@@ -147,22 +140,21 @@ import Header from "./Header.astro";
 							<h2
 								class="text-[#111418] text-base font-bold leading-tight"
 							>
-								Cloud Solutions
+                                                                {t.services[2].title}
 							</h2>
 							<p
 								class="text-[#60758a] text-sm font-normal leading-normal"
 							>
-								Leverage cloud platforms to enhance your
-								application's performance and availability.
+                                                                {t.services[2].description}
 							</p>
 						</div>
 					</div>
 				</div>
-				<h2
-					class="text-[#111418] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
-				>
-					Recent Projects
-				</h2>
+                                <h2
+                                        class="text-[#111418] text-[22px] font-bold leading-tight tracking-[-0.015em] px-4 pb-3 pt-5"
+                                >
+                                        {t.projectsTitle}
+                                </h2>
 				<div
 					class="flex overflow-y-auto [-ms-scrollbar-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
 				>
@@ -179,14 +171,12 @@ import Header from "./Header.astro";
 								<p
 									class="text-[#111418] text-base font-medium leading-normal"
 								>
-									Automated Deployment Pipeline
+                                                                        {t.project1.title}
 								</p>
 								<p
 									class="text-[#60758a] text-sm font-normal leading-normal"
 								>
-									Streamlined deployment process for a
-									large-scale application, reducing deployment
-									time by 60%.
+                                                                        {t.project1.description}
 								</p>
 							</div>
 						</div>
@@ -202,14 +192,12 @@ import Header from "./Header.astro";
 								<p
 									class="text-[#111418] text-base font-medium leading-normal"
 								>
-									Cloud Migration for E-commerce Platform
+                                                                        {t.project2.title}
 								</p>
 								<p
 									class="text-[#60758a] text-sm font-normal leading-normal"
 								>
-									Migrated an e-commerce platform to a
-									cloud-based infrastructure, improving
-									scalability and reducing costs.
+                                                                        {t.project2.description}
 								</p>
 							</div>
 						</div>
@@ -225,14 +213,12 @@ import Header from "./Header.astro";
 								<p
 									class="text-[#111418] text-base font-medium leading-normal"
 								>
-									Enhanced Testing Automation
+                                                                        {t.project3.title}
 								</p>
 								<p
 									class="text-[#60758a] text-sm font-normal leading-normal"
 								>
-									Implemented automated testing frameworks,
-									resulting in a 40% reduction in bugs and
-									faster release cycles.
+                                                                        {t.project3.description}
 								</p>
 							</div>
 						</div>
@@ -248,14 +234,14 @@ import Header from "./Header.astro";
 					<div
 						class="flex flex-wrap items-center justify-center gap-6 @[480px]:flex-row @[480px]:justify-around"
 					>
-						<a
-							class="text-[#60758a] text-base font-normal leading-normal min-w-40"
-							href="#">Privacy Policy</a
-						>
-						<a
-							class="text-[#60758a] text-base font-normal leading-normal min-w-40"
-							href="#">Terms of Service</a
-						>
+                                                <a
+                                                        class="text-[#60758a] text-base font-normal leading-normal min-w-40"
+                                                        href="#">{t.footer.privacy}</a
+                                                >
+                                                <a
+                                                        class="text-[#60758a] text-base font-normal leading-normal min-w-40"
+                                                        href="#">{t.footer.terms}</a
+                                                >
 					</div>
 					<div class="flex flex-wrap justify-center gap-4">
 						<a href="#">
@@ -319,11 +305,11 @@ import Header from "./Header.astro";
 							</div>
 						</a>
 					</div>
-					<p
-						class="text-[#60758a] text-base font-normal leading-normal"
-					>
-						© 2025 Miguel Pineda. All rights reserved.
-					</p>
+                                        <p
+                                                class="text-[#60758a] text-base font-normal leading-normal"
+                                        >
+                                                {t.footer.copyright}
+                                        </p>
 				</footer>
 			</div>
 		</footer>

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,218 @@
+export const translations = {
+  en: {
+    nav: { about: "About", projects: "Projects", contact: "Contact" },
+    welcome: {
+      heroTitle: "Streamline Your Operations with Expert DevOps Solutions",
+      heroSubtitle:
+        "I specialize in optimizing software development and deployment processes, ensuring seamless integration and efficient workflows. Let's transform your business with cutting-edge DevOps practices.",
+      buttonExplore: "Explore Services",
+      servicesTitle: "My Services",
+      services: [
+        {
+          title: "Infrastructure Automation",
+          description:
+            "Automate your infrastructure management for scalability and reliability.",
+        },
+        {
+          title: "Continuous Integration/Continuous Deployment (CI/CD)",
+          description:
+            "Implement CI/CD pipelines for faster and more reliable software releases.",
+        },
+        {
+          title: "Cloud Solutions",
+          description:
+            "Leverage cloud platforms to enhance your application's performance and availability.",
+        },
+      ],
+      projectsTitle: "Recent Projects",
+      project1: {
+        title: "Automated Deployment Pipeline",
+        description:
+          "Streamlined deployment process for a large-scale application, reducing deployment time by 60%.",
+      },
+      project2: {
+        title: "Cloud Migration for E-commerce Platform",
+        description:
+          "Migrated an e-commerce platform to a cloud-based infrastructure, improving scalability and reducing costs.",
+      },
+      project3: {
+        title: "Enhanced Testing Automation",
+        description:
+          "Implemented automated testing frameworks, resulting in a 40% reduction in bugs and faster release cycles.",
+      },
+      footer: {
+        privacy: "Privacy Policy",
+        terms: "Terms of Service",
+        copyright: "© 2025 Miguel Pineda. All rights reserved.",
+      },
+    },
+    about: {
+      profileName: "Miguel Angel Pineda Vega",
+      role: "DevOps Developer",
+      profileDesc:
+        "Experienced DevOps professional with a passion for automation and efficiency.",
+      aboutTitle: "About Me",
+      aboutDesc1:
+        "I am a seasoned DevOps engineer with over 5 years of experience in automating and streamlining software development and deployment processes. My expertise lies in building scalable and resilient infrastructure, implementing CI/CD pipelines, and fostering a collaborative DevOps culture. I am dedicated to continuous learning and staying abreast of the latest technologies to deliver innovative solutions.",
+      skillsTitle: "Technical Skills",
+      skills: [
+        "Cloud Computing",
+        "Infrastructure as Code",
+        "CI/CD",
+        "Containerization",
+        "Orchestration",
+        "Monitoring",
+        "Logging",
+        "Scripting",
+        "Configuration Management",
+        "Version Control",
+      ],
+      toolsTitle: "Tools",
+      tools: [
+        "AWS",
+        "Azure",
+        "GCP",
+        "Docker",
+        "Kubernetes",
+        "Jenkins",
+        "GitLab CI",
+        "Terraform",
+        "Ansible",
+        "Prometheus",
+        "Grafana",
+        "Git",
+      ],
+      methodologiesTitle: "Methodologies",
+      methodologies: ["Agile", "Scrum", "Kanban", "DevOps"],
+    },
+    contact: {
+      title: "Get in Touch",
+      desc:
+        "I'm always open to discussing new projects, creative ideas, or opportunities to be part of your visions. Feel free to reach out!",
+      nameLabel: "Your Name",
+      namePlaceholder: "Enter your name",
+      emailLabel: "Email Address",
+      emailPlaceholder: "Enter your email",
+      messageLabel: "Your Message",
+      messagePlaceholder: "How can I help you?",
+      sendButton: "Send Message",
+      infoTitle: "Contact Information",
+      infoEmail: "Email: contact@devopspro.com",
+      infoPhone: "Phone: (555) 123-4567",
+      socials: {
+        twitter: "Twitter",
+        linkedin: "LinkedIn",
+        github: "GitHub",
+      },
+    },
+  },
+  es: {
+    nav: { about: "Acerca de", projects: "Proyectos", contact: "Contacto" },
+    welcome: {
+      heroTitle: "Optimiza tus operaciones con soluciones DevOps expertas",
+      heroSubtitle:
+        "Me especializo en optimizar los procesos de desarrollo y despliegue de software, garantizando integraciones fluidas y flujos de trabajo eficientes. Transformemos tu negocio con prácticas DevOps de vanguardia.",
+      buttonExplore: "Explorar servicios",
+      servicesTitle: "Mis Servicios",
+      services: [
+        {
+          title: "Automatización de Infraestructura",
+          description:
+            "Automatiza la gestión de tu infraestructura para lograr escalabilidad y confiabilidad.",
+        },
+        {
+          title: "Integración Continua/Entrega Continua (CI/CD)",
+          description:
+            "Implementa pipelines de CI/CD para lanzamientos de software más rápidos y confiables.",
+        },
+        {
+          title: "Soluciones en la Nube",
+          description:
+            "Aprovecha plataformas en la nube para mejorar el rendimiento y la disponibilidad de tus aplicaciones.",
+        },
+      ],
+      projectsTitle: "Proyectos Recientes",
+      project1: {
+        title: "Pipeline de Despliegue Automatizado",
+        description:
+          "Proceso de despliegue optimizado para una aplicación a gran escala, reduciendo el tiempo de entrega en un 60%.",
+      },
+      project2: {
+        title: "Migración a la Nube para Plataforma E-commerce",
+        description:
+          "Migración de una plataforma de comercio electrónico a infraestructura en la nube, mejorando la escalabilidad y reduciendo costos.",
+      },
+      project3: {
+        title: "Mejora de Automatización de Pruebas",
+        description:
+          "Implementación de marcos de pruebas automatizadas, logrando una reducción del 40% de errores y ciclos de lanzamiento más rápidos.",
+      },
+      footer: {
+        privacy: "Política de Privacidad",
+        terms: "Términos del Servicio",
+        copyright: "© 2025 Miguel Pineda. Todos los derechos reservados.",
+      },
+    },
+    about: {
+      profileName: "Miguel Angel Pineda Vega",
+      role: "Desarrollador DevOps",
+      profileDesc:
+        "Profesional de DevOps con experiencia, apasionado por la automatización y la eficiencia.",
+      aboutTitle: "Sobre Mí",
+      aboutDesc1:
+        "Soy un ingeniero DevOps con más de 5 años de experiencia automatizando y optimizando procesos de desarrollo y despliegue de software. Mi especialidad es construir infraestructura escalable y resistente, implementar pipelines de CI/CD y fomentar una cultura DevOps colaborativa. Estoy comprometido con el aprendizaje continuo y con mantenerme al día con las últimas tecnologías para ofrecer soluciones innovadoras.",
+      skillsTitle: "Habilidades Técnicas",
+      skills: [
+        "Computación en la Nube",
+        "Infraestructura como Código",
+        "CI/CD",
+        "Contenerización",
+        "Orquestación",
+        "Monitoreo",
+        "Registro",
+        "Scripting",
+        "Gestión de Configuración",
+        "Control de Versiones",
+      ],
+      toolsTitle: "Herramientas",
+      tools: [
+        "AWS",
+        "Azure",
+        "GCP",
+        "Docker",
+        "Kubernetes",
+        "Jenkins",
+        "GitLab CI",
+        "Terraform",
+        "Ansible",
+        "Prometheus",
+        "Grafana",
+        "Git",
+      ],
+      methodologiesTitle: "Metodologías",
+      methodologies: ["Ágil", "Scrum", "Kanban", "DevOps"],
+    },
+    contact: {
+      title: "Ponte en Contacto",
+      desc:
+        "Siempre estoy abierto a hablar sobre nuevos proyectos, ideas creativas u oportunidades para ser parte de tus visiones. ¡No dudes en contactarme!",
+      nameLabel: "Tu Nombre",
+      namePlaceholder: "Ingresa tu nombre",
+      emailLabel: "Correo Electrónico",
+      emailPlaceholder: "Ingresa tu correo electrónico",
+      messageLabel: "Tu Mensaje",
+      messagePlaceholder: "¿Cómo puedo ayudarte?",
+      sendButton: "Enviar Mensaje",
+      infoTitle: "Información de Contacto",
+      infoEmail: "Correo: contact@devopspro.com",
+      infoPhone: "Teléfono: (555) 123-4567",
+      socials: {
+        twitter: "Twitter",
+        linkedin: "LinkedIn",
+        github: "GitHub",
+      },
+    },
+  },
+} as const;
+
+export type SupportedLang = keyof typeof translations;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,9 +1,10 @@
 ---
- import '../styles/global.css'
+import '../styles/global.css'
+const { lang = 'en' } = Astro.props;
 ---
 
 <!doctype html>
-<html lang="en">
+<html lang={lang}>
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,11 +1,15 @@
 ---
 import Contact from '../components/Contact.astro';
 import Layout from '../layouts/Layout.astro';
+import { translations } from '../i18n';
+
+const lang = 'en';
+const t = translations[lang];
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
 // Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
 ---
 
-<Layout>
-	<Contact />
+<Layout lang={lang}>
+        <Contact t={{ nav: t.nav, ...t.contact }} lang={lang} />
 </Layout>

--- a/src/pages/es/about.astro
+++ b/src/pages/es/about.astro
@@ -1,9 +1,9 @@
 ---
-import About from '../components/About.astro';
-import Layout from '../layouts/Layout.astro';
-import { translations } from '../i18n';
+import About from '../../components/About.astro';
+import Layout from '../../layouts/Layout.astro';
+import { translations } from '../../i18n';
 
-const lang = 'en';
+const lang = 'es';
 const t = translations[lang];
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build

--- a/src/pages/es/contact.astro
+++ b/src/pages/es/contact.astro
@@ -1,9 +1,9 @@
 ---
-import About from '../components/About.astro';
-import Layout from '../layouts/Layout.astro';
-import { translations } from '../i18n';
+import Contact from '../../components/Contact.astro';
+import Layout from '../../layouts/Layout.astro';
+import { translations } from '../../i18n';
 
-const lang = 'en';
+const lang = 'es';
 const t = translations[lang];
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
@@ -11,5 +11,5 @@ const t = translations[lang];
 ---
 
 <Layout lang={lang}>
-        <About t={{ nav: t.nav, ...t.about }} lang={lang} />
+        <Contact t={{ nav: t.nav, ...t.contact }} lang={lang} />
 </Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,9 +1,9 @@
 ---
-import About from '../components/About.astro';
-import Layout from '../layouts/Layout.astro';
-import { translations } from '../i18n';
+import Welcome from '../../components/Welcome.astro';
+import Layout from '../../layouts/Layout.astro';
+import { translations } from '../../i18n';
 
-const lang = 'en';
+const lang = 'es';
 const t = translations[lang];
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
@@ -11,5 +11,5 @@ const t = translations[lang];
 ---
 
 <Layout lang={lang}>
-        <About t={{ nav: t.nav, ...t.about }} lang={lang} />
+        <Welcome t={{ nav: t.nav, ...t.welcome }} lang={lang} />
 </Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,15 @@
 ---
 import Welcome from '../components/Welcome.astro';
 import Layout from '../layouts/Layout.astro';
+import { translations } from '../i18n';
+
+const lang = 'en';
+const t = translations[lang];
 
 // Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
 // Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
 ---
 
-<Layout>
-	<Welcome />
+<Layout lang={lang}>
+        <Welcome t={{ nav: t.nav, ...t.welcome }} lang={lang} />
 </Layout>


### PR DESCRIPTION
## Summary
- add English and Spanish translations
- make layout lang-aware
- update header with language switcher
- create Spanish versions of pages under `/es`

## Testing
- `pnpm build` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_685f021c738c832781cd2b0f36dab7e3