### PR TITLE
feat: Add live WebGL aura backdrop (Three.js noise shader)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
     "@tailwindcss/vite": "^4.1.11",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
+    "@types/three": "^0.185.1",
     "astro": "^5.16.5",
     "lucide-react": "^1.7.0",
     "motion": "^12.38.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "tailwindcss": "^4.1.11"
+    "tailwindcss": "^4.1.11",
+    "three": "^0.185.1"
   },
   "packageManager": "pnpm@9.1.4"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.6
         version: 19.1.6(@types/react@19.1.8)
+      '@types/three':
+        specifier: ^0.185.1
+        version: 0.185.1
       astro:
         specifier: ^5.16.5
         version: 5.16.5(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.44.1)(typescript@5.8.3)
@@ -44,6 +47,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
+      three:
+        specifier: ^0.185.1
+        version: 0.185.1
 
 packages:
 
@@ -176,6 +182,9 @@ packages:
   '@capsizecss/unpack@3.0.1':
     resolution: {integrity: sha512-8XqW8xGn++Eqqbz3e9wKuK7mxryeRjs4LOHLxbh2lwKeSbuNR4NFifDZT4KzvjU6HMOPbiNTsWpniK5EJfTWkg==}
     engines: {node: '>=18'}
+
+  '@dimforge/rapier3d-compat@0.12.0':
+    resolution: {integrity: sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==}
 
   '@emnapi/runtime@1.7.1':
     resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
@@ -736,6 +745,9 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7
 
+  '@tweenjs/tween.js@23.1.3':
+    resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -780,8 +792,17 @@ packages:
   '@types/react@19.1.8':
     resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
 
+  '@types/stats.js@0.17.4':
+    resolution: {integrity: sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==}
+
+  '@types/three@0.185.1':
+    resolution: {integrity: sha512-db1xTb+EgYF2didW+eudSvVPtn75zo+fGsY8ShQrJY/B5ZBmC2Fiaykv3aImHAlCNEGuMPkPGXBJGLwzu5mC7A==}
+
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
+
+  '@types/webxr@0.5.24':
+    resolution: {integrity: sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==}
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
@@ -1101,6 +1122,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
@@ -1373,6 +1397,9 @@ packages:
 
   mdn-data@2.12.2:
     resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
+
+  meshoptimizer@1.1.1:
+    resolution: {integrity: sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1751,6 +1778,9 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+
+  three@0.185.1:
+    resolution: {integrity: sha512-5aojFCXKwnjBRZvUnt3WFfEcvUJgkN5LlijRFN95hMy8WVkG4I0QNcJE+OuWvuJ0bOdStrbfXn0pkd6/QyiAlg==}
 
   tiny-inflate@1.0.3:
     resolution: {integrity: sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==}
@@ -2235,6 +2265,8 @@ snapshots:
     dependencies:
       fontkit: 2.0.4
 
+  '@dimforge/rapier3d-compat@0.12.0': {}
+
   '@emnapi/runtime@1.7.1':
     dependencies:
       tslib: 2.8.1
@@ -2634,6 +2666,8 @@ snapshots:
       tailwindcss: 4.1.11
       vite: 6.4.1(@types/node@24.0.4)(jiti@2.4.2)(lightningcss@1.30.1)
 
+  '@tweenjs/tween.js@23.1.3': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.27.7
@@ -2691,7 +2725,20 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@types/stats.js@0.17.4': {}
+
+  '@types/three@0.185.1':
+    dependencies:
+      '@dimforge/rapier3d-compat': 0.12.0
+      '@tweenjs/tween.js': 23.1.3
+      '@types/stats.js': 0.17.4
+      '@types/webxr': 0.5.24
+      fflate: 0.8.3
+      meshoptimizer: 1.1.1
+
   '@types/unist@3.0.3': {}
+
+  '@types/webxr@0.5.24': {}
 
   '@ungap/structured-clone@1.3.0': {}
 
@@ -3063,6 +3110,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.3: {}
 
   flattie@1.1.1: {}
 
@@ -3436,6 +3485,8 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.12.2: {}
+
+  meshoptimizer@1.1.1: {}
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4001,6 +4052,8 @@ snapshots:
       minizlib: 3.0.2
       mkdirp: 3.0.1
       yallist: 5.0.0
+
+  three@0.185.1: {}
 
   tiny-inflate@1.0.3: {}
 

--- a/src/components/Backdrop.tsx
+++ b/src/components/Backdrop.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useRef } from "react";
+import * as THREE from "three";
+
+/**
+ * Backdrop — a full-screen WebGL "aura".
+ *
+ * A single fragment shader renders slow, domain-warped fractal noise tinted
+ * with the site accent, plus a cursor-following glow, film grain and a vignette.
+ * It reads the live theme colours from CSS variables and eases between them,
+ * pauses when the tab is hidden, and freezes for prefers-reduced-motion.
+ */
+
+const VERT = /* glsl */ `
+  void main() { gl_Position = vec4(position.xy, 0.0, 1.0); }
+`;
+
+const FRAG = /* glsl */ `
+  precision highp float;
+
+  uniform vec2  uRes;
+  uniform float uTime;
+  uniform vec2  uMouse;      // 0..1
+  uniform vec3  uBg;
+  uniform vec3  uAccent;
+  uniform float uReduce;     // 1.0 => frozen
+
+  // -- value noise + fbm ----------------------------------------------------
+  float hash(vec2 p) {
+    p = fract(p * vec2(123.34, 456.21));
+    p += dot(p, p + 45.32);
+    return fract(p.x * p.y);
+  }
+  float noise(vec2 p) {
+    vec2 i = floor(p), f = fract(p);
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+    vec2 u = f * f * (3.0 - 2.0 * f);
+    return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+  }
+  float fbm(vec2 p) {
+    float v = 0.0, amp = 0.5;
+    for (int i = 0; i < 5; i++) {
+      v += amp * noise(p);
+      p *= 2.02;
+      amp *= 0.5;
+    }
+    return v;
+  }
+
+  void main() {
+    vec2 uv = gl_FragCoord.xy / uRes.xy;
+    vec2 p  = (gl_FragCoord.xy - 0.5 * uRes) / min(uRes.x, uRes.y);
+
+    float t = uTime * 0.02 * (1.0 - uReduce);
+    vec2  m = (uMouse - 0.5);
+
+    // domain warping — flowing organic bands
+    vec2 q = vec2(fbm(p * 1.6 + t), fbm(p * 1.6 + vec2(5.2, 1.3) - t));
+    vec2 r = vec2(
+      fbm(p * 1.6 + 2.0 * q + vec2(1.7, 9.2) + m * 0.35),
+      fbm(p * 1.6 + 2.0 * q + vec2(8.3, 2.8) - m * 0.35)
+    );
+    float f = fbm(p * 1.6 + 2.0 * r + t * 0.6);
+    f = smoothstep(0.05, 0.95, f);
+
+    // base: mostly background, accent only glinting in the crests
+    vec3 col = mix(uBg, uAccent, f * 0.20);
+
+    // soft glow that trails the cursor
+    vec2 gp = p - m;
+    float glow = 0.05 / (0.05 + dot(gp, gp));
+    col += uAccent * glow * 0.035;
+
+    // subtle secondary accent pool, off-centre, for depth
+    float pool = 0.10 / (0.10 + dot(p - vec2(0.55, -0.35), p - vec2(0.55, -0.35)));
+    col += uAccent * pool * 0.02;
+
+    // film grain
+    col += (hash(gl_FragCoord.xy + fract(t)) - 0.5) * 0.018;
+
+    // vignette so edges stay calm
+    float vig = smoothstep(1.15, 0.25, length(uv - 0.5));
+    col = mix(uBg, col, 0.35 + vig * 0.65);
+
+    gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+function readVar(name: string): THREE.Color {
+  const raw = getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+  return new THREE.Color(raw || "#000000");
+}
+
+export default function Backdrop() {
+  const ref = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = ref.current;
+    if (!canvas) return;
+
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({ canvas, antialias: false, alpha: false, powerPreference: "low-power" });
+    } catch {
+      return; // no WebGL — the CSS background stays as a graceful fallback
+    }
+
+    const reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const DPR = Math.min(window.devicePixelRatio || 1, 1.5);
+    renderer.setPixelRatio(DPR);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.Camera();
+
+    const bg = readVar("--bg");
+    const accent = readVar("--accent");
+
+    const uniforms = {
+      uRes: { value: new THREE.Vector2() },
+      uTime: { value: 0 },
+      uMouse: { value: new THREE.Vector2(0.5, 0.5) },
+      uBg: { value: bg.clone() },
+      uAccent: { value: accent.clone() },
+      uReduce: { value: reduce ? 1 : 0 },
+    };
+    // targets we ease toward on theme change
+    const targetBg = bg.clone();
+    const targetAccent = accent.clone();
+
+    const material = new THREE.ShaderMaterial({ vertexShader: VERT, fragmentShader: FRAG, uniforms, depthTest: false });
+    const quad = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
+    scene.add(quad);
+
+    const resize = () => {
+      const w = window.innerWidth, h = window.innerHeight;
+      renderer.setSize(w, h, false);
+      uniforms.uRes.value.set(w * DPR, h * DPR);
+    };
+    resize();
+    window.addEventListener("resize", resize);
+
+    // smoothed pointer
+    const mouse = new THREE.Vector2(0.5, 0.5);
+    const onMove = (e: PointerEvent) => {
+      mouse.set(e.clientX / window.innerWidth, 1 - e.clientY / window.innerHeight);
+    };
+    window.addEventListener("pointermove", onMove, { passive: true });
+
+    // re-read colours when the theme flips
+    const themeObserver = new MutationObserver(() => {
+      targetBg.copy(readVar("--bg"));
+      targetAccent.copy(readVar("--accent"));
+    });
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+
+    let raf = 0;
+    let last = 0;
+    const clock = new THREE.Clock();
+
+    const frame = () => {
+      const dt = clock.getDelta();
+      uniforms.uTime.value += dt;
+
+      // ease pointer + theme colours
+      uniforms.uMouse.value.lerp(mouse, 0.05);
+      uniforms.uBg.value.lerp(targetBg, 0.06);
+      uniforms.uAccent.value.lerp(targetAccent, 0.06);
+
+      renderer.render(scene, camera);
+      if (!reduce) raf = requestAnimationFrame(frame);
+    };
+
+    const onVisibility = () => {
+      if (document.hidden) {
+        cancelAnimationFrame(raf);
+        raf = 0;
+      } else if (!raf && !reduce) {
+        clock.getDelta(); // discard the gap
+        raf = requestAnimationFrame(frame);
+      }
+    };
+    document.addEventListener("visibilitychange", onVisibility);
+
+    if (reduce) {
+      renderer.render(scene, camera); // one static frame
+    } else {
+      raf = requestAnimationFrame(frame);
+    }
+
+    return () => {
+      cancelAnimationFrame(raf);
+      window.removeEventListener("resize", resize);
+      window.removeEventListener("pointermove", onMove);
+      document.removeEventListener("visibilitychange", onVisibility);
+      themeObserver.disconnect();
+      material.dispose();
+      quad.geometry.dispose();
+      renderer.dispose();
+    };
+  }, []);
+
+  return <canvas ref={ref} id="backdrop" aria-hidden="true" />;
+}

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -37,7 +37,10 @@ const c = t.contact;
 </section>
 
 <style>
-  .contact { padding: var(--section-py) 0; background: var(--surface); }
+  .contact {
+    padding: var(--section-py) 0;
+    background: color-mix(in srgb, var(--surface) 60%, transparent);
+  }
 
   .contact-lead {
     font-size: clamp(1.8rem, 4vw, 3rem);

--- a/src/components/Home.astro
+++ b/src/components/Home.astro
@@ -7,6 +7,7 @@ import Journey from './Journey.astro';
 import Contact from './Contact.astro';
 import Footer from './Footer.astro';
 import ScrollReveal from './ScrollReveal.tsx';
+import Backdrop from './Backdrop.tsx';
 
 interface Props {
   t: any;
@@ -16,6 +17,7 @@ interface Props {
 const { t, lang } = Astro.props;
 ---
 
+<Backdrop client:load />
 <ScrollReveal client:load />
 <Navbar t={t} lang={lang} />
 <main>

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -37,7 +37,10 @@ const c = t.capabilities;
 </section>
 
 <style>
-  .cap { padding: var(--section-py) 0; background: var(--surface); }
+  .cap {
+    padding: var(--section-py) 0;
+    background: color-mix(in srgb, var(--surface) 60%, transparent);
+  }
 
   .rows {
     list-style: none;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -113,6 +113,19 @@ img {
 ::-webkit-scrollbar-track { background: var(--bg); }
 ::-webkit-scrollbar-thumb { background: var(--hairline-strong); border-radius: 99px; }
 
+/* ---------- WebGL backdrop ---------- */
+#backdrop {
+  position: fixed;
+  inset: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 0;
+  display: block;
+  pointer-events: none;
+}
+/* Lift real content above the aura */
+main, .footer { position: relative; z-index: 1; }
+
 /* ---------- Shared primitives ---------- */
 .wrap {
   max-width: var(--maxw);


### PR DESCRIPTION
## Overview

Replaces the flat background with a subtle, animated GPU-rendered "aura" so the site reads as genuinely modern rather than another static editorial template. Builds on top of the merged **"The Index"** redesign (#6).

## What's in it

- **Custom GLSL fragment shader** (`src/components/Backdrop.tsx`): slow domain-warped fractal noise (5-octave FBM) tinted with the accent, plus a cursor-following glow, an off-centre accent pool for depth, film grain and a vignette.
- **Theme-aware**: reads `--bg` / `--accent` from CSS and eases between them on the dark/light toggle — no flashing.
- **Respectful & performant**: freezes for `prefers-reduced-motion`, pauses when the tab is hidden, caps DPR at 1.5, renders a single full-screen quad with a `low-power` hint.
- **Graceful fallback**: if WebGL is unavailable, the CSS background stays as-is.
- Capabilities and contact panels made translucent so the aura bleeds subtly through the whole page, not just the hero.

## Notes

- Adds `three` + `@types/three` as dependencies.
- Verified `pnpm build` is clean; visually checked hero, capabilities, dark, and light.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C6oaChBiLxypZHDcQsk5YG

---
_Generated by [Claude Code](https://claude.ai/code/session_01C6oaChBiLxypZHDcQsk5YG)_